### PR TITLE
nobug: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ issues.
 The `go-groups` command can be installed by running:
 
 ```
-$ go get oss.indeed.com/go/go-groups
+$ go install oss.indeed.com/go/go-groups@latest
 ```
 
 # Usage


### PR DESCRIPTION
Go is moving away from using `go get` to install tools, using
`go install` instead.

https://golang.org/doc/go-get-install-deprecation
